### PR TITLE
Created material symbol components and tests for it

### DIFF
--- a/app/components/materialSymbol.tsx
+++ b/app/components/materialSymbol.tsx
@@ -1,51 +1,47 @@
 import 'material-symbols';
 
 interface MaterialSymbolProps {
-    symbol: string;
-    type?: 'outlined' | 'rounded' | 'sharp';
-    fill?: boolean;
-    weight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
-    grade?: -25 | 0 | 200;
-    size?: 18 | 24 | 36 | 48 | number;
-    color?: string;
-    className?: string;
-    style?: React.CSSProperties;
+  symbol: string;
+  type?: 'outlined' | 'rounded' | 'sharp';
+  fill?: boolean;
+  weight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
+  grade?: -25 | 0 | 200;
+  size?: 18 | 24 | 36 | 48 | number;
+  color?: string;
+  className?: string;
+  style?: React.CSSProperties;
 }
 
 export default function MaterialSymbol({
-    symbol,
-    type = 'outlined',
-    fill = false,
-    weight,
-    grade,
-    size,
-    color,
-    className = '',
-    style = {},
+  symbol,
+  type = 'outlined',
+  fill = false,
+  weight,
+  grade,
+  size,
+  color,
+  className = '',
+  style = {},
 }: MaterialSymbolProps) {
-    const classNames = [
-        `material-symbols-${type}`,
-        className,
-    ].filter(Boolean).join(' ');
+  const classNames = [`material-symbols-${type}`, className]
+    .filter(Boolean)
+    .join(' ');
 
-    const styles = {
-        fontVariationSettings: `
+  const styles = {
+    fontVariationSettings: `
             'FILL' ${fill ? 1 : 0},
             'wght' ${weight || 400},
             'GRAD' ${grade || 0},
             'opsz' ${size || 24}
         `,
-        fontSize: size ? `${size}px` : undefined,
-        color: color || undefined,
-        ...style,
-    };
+    fontSize: size ? `${size}px` : undefined,
+    color: color || undefined,
+    ...style,
+  };
 
-    return (
-        <span 
-            className={classNames}
-            style={styles}
-        >
-            {symbol}
-        </span>
-    );
+  return (
+    <span className={classNames} style={styles}>
+      {symbol}
+    </span>
+  );
 }

--- a/app/components/materialSymbol.tsx
+++ b/app/components/materialSymbol.tsx
@@ -1,3 +1,5 @@
+import 'material-symbols';
+
 interface MaterialSymbolProps {
     symbol: string;
     type?: 'outlined' | 'rounded' | 'sharp';

--- a/app/components/materialSymbol.tsx
+++ b/app/components/materialSymbol.tsx
@@ -1,0 +1,49 @@
+interface MaterialSymbolProps {
+    symbol: string;
+    type?: 'outlined' | 'rounded' | 'sharp';
+    fill?: boolean;
+    weight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
+    grade?: -25 | 0 | 200;
+    size?: 18 | 24 | 36 | 48 | number;
+    color?: string;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+export default function MaterialSymbol({
+    symbol,
+    type = 'outlined',
+    fill = false,
+    weight,
+    grade,
+    size,
+    color,
+    className = '',
+    style = {},
+}: MaterialSymbolProps) {
+    const classNames = [
+        `material-symbols-${type}`,
+        className,
+    ].filter(Boolean).join(' ');
+
+    const styles = {
+        fontVariationSettings: `
+            'FILL' ${fill ? 1 : 0},
+            'wght' ${weight || 400},
+            'GRAD' ${grade || 0},
+            'opsz' ${size || 24}
+        `,
+        fontSize: size ? `${size}px` : undefined,
+        color: color || undefined,
+        ...style,
+    };
+
+    return (
+        <span 
+            className={classNames}
+            style={styles}
+        >
+            {symbol}
+        </span>
+    );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@reduxjs/toolkit": "^2.5.0",
         "@tailwindcss/postcss": "^4.0.0",
         "framer-motion": "^12.0.1",
+        "material-symbols": "^0.28.0",
         "next": "15.1.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -10806,6 +10807,12 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/material-symbols": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.28.0.tgz",
+      "integrity": "sha512-zzio5i3GCe5mnAd3kEgoMu35uDbHw9bBdh8hEVYBrsmegm6L0PgUPQQ2iTBjw6H0V8k15Mo0KF7jUo7UwrY5HA==",
+      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@reduxjs/toolkit": "^2.5.0",
     "@tailwindcss/postcss": "^4.0.0",
     "framer-motion": "^12.0.1",
+    "material-symbols": "^0.28.0",
     "next": "15.1.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/tests/__mocks__/material-symbols.ts
+++ b/tests/__mocks__/material-symbols.ts
@@ -7,8 +7,8 @@ const materialSymbols = {
 const css = {
   'material-symbols-outlined': 'material-symbols-outlined',
   'material-symbols-rounded': 'material-symbols-rounded',
-  'material-symbols-sharp': 'material-symbols-sharp'
+  'material-symbols-sharp': 'material-symbols-sharp',
 };
 
 export { css };
-export default materialSymbols; 
+export default materialSymbols;

--- a/tests/__mocks__/material-symbols.ts
+++ b/tests/__mocks__/material-symbols.ts
@@ -1,0 +1,14 @@
+// Mock for material-symbols package
+const materialSymbols = {
+  // Add any specific exports if needed
+};
+
+// Mock CSS module
+const css = {
+  'material-symbols-outlined': 'material-symbols-outlined',
+  'material-symbols-rounded': 'material-symbols-rounded',
+  'material-symbols-sharp': 'material-symbols-sharp'
+};
+
+export { css };
+export default materialSymbols; 

--- a/tests/integration/components/MaterialSymbol.test.tsx
+++ b/tests/integration/components/MaterialSymbol.test.tsx
@@ -8,12 +8,12 @@ describe('MaterialSymbol Integration', () => {
       <button>
         <MaterialSymbol symbol="add" />
         Add Item
-      </button>
+      </button>,
     );
-    
+
     const icon = screen.getByText('add');
     const button = icon.closest('button');
-    
+
     expect(icon).toBeInTheDocument();
     expect(button).toHaveTextContent('add');
     expect(button).toHaveTextContent('Add Item');
@@ -34,17 +34,17 @@ describe('MaterialSymbol Integration', () => {
         <MaterialSymbol symbol="star" color="gold" />
         <MaterialSymbol symbol="star" color="gold" />
         <MaterialSymbol symbol="star" color="gray" />
-      </div>
+      </div>,
     );
 
     const stars = screen.getAllByText('star');
     expect(stars).toHaveLength(3);
-    
-    stars.slice(0, 2).forEach(star => {
+
+    stars.slice(0, 2).forEach((star) => {
       const style = window.getComputedStyle(star);
       expect(style.color).toBe('rgb(255, 215, 0)'); // gold in RGB
     });
-    
+
     const style = window.getComputedStyle(stars[2]);
     expect(style.color).toBe('rgb(128, 128, 128)'); // gray in RGB
   });
@@ -54,7 +54,7 @@ describe('MaterialSymbol Integration', () => {
       <div>
         {true && <MaterialSymbol symbol="check" color="green" />}
         {false && <MaterialSymbol symbol="close" color="red" />}
-      </div>
+      </div>,
     );
 
     expect(screen.getByText('check')).toBeInTheDocument();
@@ -64,7 +64,7 @@ describe('MaterialSymbol Integration', () => {
       <div>
         {false && <MaterialSymbol symbol="check" color="green" />}
         {true && <MaterialSymbol symbol="close" color="red" />}
-      </div>
+      </div>,
     );
 
     expect(screen.queryByText('check')).not.toBeInTheDocument();
@@ -73,29 +73,23 @@ describe('MaterialSymbol Integration', () => {
 
   it('works with dynamic styles based on state', () => {
     const { rerender } = render(
-      <MaterialSymbol 
-        symbol="favorite" 
-        fill={false}
-        color="gray" 
-      />
+      <MaterialSymbol symbol="favorite" fill={false} color="gray" />,
     );
 
     let icon = screen.getByText('favorite');
     const style = window.getComputedStyle(icon);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 0`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'FILL' 0`,
+    );
     expect(style.color).toBe('rgb(128, 128, 128)'); // gray in RGB
 
-    rerender(
-      <MaterialSymbol 
-        symbol="favorite" 
-        fill={true}
-        color="red" 
-      />
-    );
+    rerender(<MaterialSymbol symbol="favorite" fill={true} color="red" />);
 
     icon = screen.getByText('favorite');
     const newStyle = window.getComputedStyle(icon);
-    expect(newStyle.getPropertyValue('font-variation-settings')).toContain(`'FILL' 1`);
+    expect(newStyle.getPropertyValue('font-variation-settings')).toContain(
+      `'FILL' 1`,
+    );
     expect(newStyle.color).toBe('rgb(255, 0, 0)'); // red in RGB
   });
 
@@ -110,7 +104,7 @@ describe('MaterialSymbol Integration', () => {
       <Wrapper>
         <MaterialSymbol symbol="info" />
         <MaterialSymbol symbol="warning" color="orange" />
-      </Wrapper>
+      </Wrapper>,
     );
 
     const infoIcon = screen.getByText('info');
@@ -124,4 +118,4 @@ describe('MaterialSymbol Integration', () => {
     const warningStyle = window.getComputedStyle(warningIcon);
     expect(warningStyle.color).toBe('rgb(255, 165, 0)'); // orange in RGB
   });
-}); 
+});

--- a/tests/integration/components/MaterialSymbol.test.tsx
+++ b/tests/integration/components/MaterialSymbol.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../utils/test-utils';
+import MaterialSymbol from '@/app/components/materialSymbol';
+
+describe('MaterialSymbol Integration', () => {
+  it('works within a button component', () => {
+    render(
+      <button>
+        <MaterialSymbol symbol="add" />
+        Add Item
+      </button>
+    );
+    
+    const icon = screen.getByText('add');
+    const button = icon.closest('button');
+    
+    expect(icon).toBeInTheDocument();
+    expect(button).toHaveTextContent('add');
+    expect(button).toHaveTextContent('Add Item');
+  });
+
+  it('works with dynamic symbol changes', () => {
+    const { rerender } = render(<MaterialSymbol symbol="play_arrow" />);
+    expect(screen.getByText('play_arrow')).toBeInTheDocument();
+
+    rerender(<MaterialSymbol symbol="pause" />);
+    expect(screen.getByText('pause')).toBeInTheDocument();
+    expect(screen.queryByText('play_arrow')).not.toBeInTheDocument();
+  });
+
+  it('works with multiple icons in the same container', () => {
+    render(
+      <div>
+        <MaterialSymbol symbol="star" color="gold" />
+        <MaterialSymbol symbol="star" color="gold" />
+        <MaterialSymbol symbol="star" color="gray" />
+      </div>
+    );
+
+    const stars = screen.getAllByText('star');
+    expect(stars).toHaveLength(3);
+    
+    stars.slice(0, 2).forEach(star => {
+      const style = window.getComputedStyle(star);
+      expect(style.color).toBe('rgb(255, 215, 0)'); // gold in RGB
+    });
+    
+    const style = window.getComputedStyle(stars[2]);
+    expect(style.color).toBe('rgb(128, 128, 128)'); // gray in RGB
+  });
+
+  it('works with conditional rendering', () => {
+    const { rerender } = render(
+      <div>
+        {true && <MaterialSymbol symbol="check" color="green" />}
+        {false && <MaterialSymbol symbol="close" color="red" />}
+      </div>
+    );
+
+    expect(screen.getByText('check')).toBeInTheDocument();
+    expect(screen.queryByText('close')).not.toBeInTheDocument();
+
+    rerender(
+      <div>
+        {false && <MaterialSymbol symbol="check" color="green" />}
+        {true && <MaterialSymbol symbol="close" color="red" />}
+      </div>
+    );
+
+    expect(screen.queryByText('check')).not.toBeInTheDocument();
+    expect(screen.getByText('close')).toBeInTheDocument();
+  });
+
+  it('works with dynamic styles based on state', () => {
+    const { rerender } = render(
+      <MaterialSymbol 
+        symbol="favorite" 
+        fill={false}
+        color="gray" 
+      />
+    );
+
+    let icon = screen.getByText('favorite');
+    const style = window.getComputedStyle(icon);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 0`);
+    expect(style.color).toBe('rgb(128, 128, 128)'); // gray in RGB
+
+    rerender(
+      <MaterialSymbol 
+        symbol="favorite" 
+        fill={true}
+        color="red" 
+      />
+    );
+
+    icon = screen.getByText('favorite');
+    const newStyle = window.getComputedStyle(icon);
+    expect(newStyle.getPropertyValue('font-variation-settings')).toContain(`'FILL' 1`);
+    expect(newStyle.color).toBe('rgb(255, 0, 0)'); // red in RGB
+  });
+
+  it('works with nested components and inheritance', () => {
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <div className="wrapper" style={{ color: 'blue' }}>
+        {children}
+      </div>
+    );
+
+    render(
+      <Wrapper>
+        <MaterialSymbol symbol="info" />
+        <MaterialSymbol symbol="warning" color="orange" />
+      </Wrapper>
+    );
+
+    const infoIcon = screen.getByText('info');
+    const warningIcon = screen.getByText('warning');
+
+    // Info icon should inherit parent color
+    const infoStyle = window.getComputedStyle(infoIcon);
+    expect(infoStyle.color).toBe('rgb(0, 0, 255)'); // blue in RGB
+
+    // Warning icon should override parent color
+    const warningStyle = window.getComputedStyle(warningIcon);
+    expect(warningStyle.color).toBe('rgb(255, 165, 0)'); // orange in RGB
+  });
+}); 

--- a/tests/unit/components/MaterialSymbol.test.tsx
+++ b/tests/unit/components/MaterialSymbol.test.tsx
@@ -6,61 +6,77 @@ describe('MaterialSymbol', () => {
   it('renders with default props', () => {
     render(<MaterialSymbol symbol="home" />);
     const icon = screen.getByText('home');
-    
+
     expect(icon).toBeInTheDocument();
     expect(icon).toHaveClass('material-symbols-outlined');
-    
+
     const style = window.getComputedStyle(icon);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 0`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'wght' 400`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'GRAD' 0`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'opsz' 24`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'FILL' 0`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'wght' 400`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'GRAD' 0`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'opsz' 24`,
+    );
   });
 
   it('renders with custom type', () => {
     render(<MaterialSymbol symbol="home" type="rounded" />);
     const icon = screen.getByText('home');
-    
+
     expect(icon).toHaveClass('material-symbols-rounded');
   });
 
   it('renders with fill enabled', () => {
     render(<MaterialSymbol symbol="home" fill={true} />);
     const icon = screen.getByText('home');
-    
+
     const style = window.getComputedStyle(icon);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 1`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'FILL' 1`,
+    );
   });
 
   it('applies custom weight', () => {
     render(<MaterialSymbol symbol="home" weight={700} />);
     const icon = screen.getByText('home');
-    
+
     const style = window.getComputedStyle(icon);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'wght' 700`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'wght' 700`,
+    );
   });
 
   it('applies custom grade', () => {
     render(<MaterialSymbol symbol="home" grade={200} />);
     const icon = screen.getByText('home');
-    
+
     const style = window.getComputedStyle(icon);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'GRAD' 200`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'GRAD' 200`,
+    );
   });
 
   it('applies custom size', () => {
     render(<MaterialSymbol symbol="home" size={36} />);
     const icon = screen.getByText('home');
-    
+
     const style = window.getComputedStyle(icon);
     expect(style.fontSize).toBe('36px');
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'opsz' 36`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'opsz' 36`,
+    );
   });
 
   it('applies custom color', () => {
     render(<MaterialSymbol symbol="home" color="#FF0000" />);
     const icon = screen.getByText('home');
-    
+
     const style = window.getComputedStyle(icon);
     expect(style.color).toBe('rgb(255, 0, 0)');
   });
@@ -68,7 +84,7 @@ describe('MaterialSymbol', () => {
   it('applies custom className', () => {
     render(<MaterialSymbol symbol="home" className="custom-class" />);
     const icon = screen.getByText('home');
-    
+
     expect(icon).toHaveClass('material-symbols-outlined', 'custom-class');
   });
 
@@ -76,7 +92,7 @@ describe('MaterialSymbol', () => {
     const customStyle = { margin: '10px', padding: '5px' };
     render(<MaterialSymbol symbol="home" style={customStyle} />);
     const icon = screen.getByText('home');
-    
+
     const style = window.getComputedStyle(icon);
     expect(style.margin).toBe('10px');
     expect(style.padding).toBe('5px');
@@ -92,19 +108,27 @@ describe('MaterialSymbol', () => {
       size: 48,
       color: '#00FF00',
       className: 'custom-class',
-      style: { margin: '10px' }
+      style: { margin: '10px' },
     };
 
     render(<MaterialSymbol {...props} />);
     const icon = screen.getByText('star');
 
     expect(icon).toHaveClass('material-symbols-sharp', 'custom-class');
-    
+
     const style = window.getComputedStyle(icon);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 1`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'wght' 800`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'GRAD' -25`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'opsz' 48`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'FILL' 1`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'wght' 800`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'GRAD' -25`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'opsz' 48`,
+    );
     expect(style.fontSize).toBe('48px');
     expect(style.color).toBe('rgb(0, 255, 0)');
     expect(style.margin).toBe('10px');
@@ -114,20 +138,35 @@ describe('MaterialSymbol', () => {
   it('handles empty className', () => {
     render(<MaterialSymbol symbol="home" className="" />);
     const icon = screen.getByText('home');
-    
+
     expect(icon).toHaveClass('material-symbols-outlined');
     expect(icon.className.trim()).toBe('material-symbols-outlined');
   });
 
   it('handles undefined optional props', () => {
-    render(<MaterialSymbol symbol="home" type={undefined} fill={undefined} weight={undefined} />);
+    render(
+      <MaterialSymbol
+        symbol="home"
+        type={undefined}
+        fill={undefined}
+        weight={undefined}
+      />,
+    );
     const icon = screen.getByText('home');
-    
+
     expect(icon).toHaveClass('material-symbols-outlined');
     const style = window.getComputedStyle(icon);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 0`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'wght' 400`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'GRAD' 0`);
-    expect(style.getPropertyValue('font-variation-settings')).toContain(`'opsz' 24`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'FILL' 0`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'wght' 400`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'GRAD' 0`,
+    );
+    expect(style.getPropertyValue('font-variation-settings')).toContain(
+      `'opsz' 24`,
+    );
   });
-}); 
+});

--- a/tests/unit/components/MaterialSymbol.test.tsx
+++ b/tests/unit/components/MaterialSymbol.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../utils/test-utils';
+import MaterialSymbol from '@/app/components/materialSymbol';
+
+describe('MaterialSymbol', () => {
+  it('renders with default props', () => {
+    render(<MaterialSymbol symbol="home" />);
+    const icon = screen.getByText('home');
+    
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('material-symbols-outlined');
+    
+    const style = window.getComputedStyle(icon);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 0`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'wght' 400`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'GRAD' 0`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'opsz' 24`);
+  });
+
+  it('renders with custom type', () => {
+    render(<MaterialSymbol symbol="home" type="rounded" />);
+    const icon = screen.getByText('home');
+    
+    expect(icon).toHaveClass('material-symbols-rounded');
+  });
+
+  it('renders with fill enabled', () => {
+    render(<MaterialSymbol symbol="home" fill={true} />);
+    const icon = screen.getByText('home');
+    
+    const style = window.getComputedStyle(icon);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 1`);
+  });
+
+  it('applies custom weight', () => {
+    render(<MaterialSymbol symbol="home" weight={700} />);
+    const icon = screen.getByText('home');
+    
+    const style = window.getComputedStyle(icon);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'wght' 700`);
+  });
+
+  it('applies custom grade', () => {
+    render(<MaterialSymbol symbol="home" grade={200} />);
+    const icon = screen.getByText('home');
+    
+    const style = window.getComputedStyle(icon);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'GRAD' 200`);
+  });
+
+  it('applies custom size', () => {
+    render(<MaterialSymbol symbol="home" size={36} />);
+    const icon = screen.getByText('home');
+    
+    const style = window.getComputedStyle(icon);
+    expect(style.fontSize).toBe('36px');
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'opsz' 36`);
+  });
+
+  it('applies custom color', () => {
+    render(<MaterialSymbol symbol="home" color="#FF0000" />);
+    const icon = screen.getByText('home');
+    
+    const style = window.getComputedStyle(icon);
+    expect(style.color).toBe('rgb(255, 0, 0)');
+  });
+
+  it('applies custom className', () => {
+    render(<MaterialSymbol symbol="home" className="custom-class" />);
+    const icon = screen.getByText('home');
+    
+    expect(icon).toHaveClass('material-symbols-outlined', 'custom-class');
+  });
+
+  it('applies custom style', () => {
+    const customStyle = { margin: '10px', padding: '5px' };
+    render(<MaterialSymbol symbol="home" style={customStyle} />);
+    const icon = screen.getByText('home');
+    
+    const style = window.getComputedStyle(icon);
+    expect(style.margin).toBe('10px');
+    expect(style.padding).toBe('5px');
+  });
+
+  it('combines all custom properties correctly', () => {
+    const props = {
+      symbol: 'star',
+      type: 'sharp' as const,
+      fill: true,
+      weight: 800 as const,
+      grade: -25 as const,
+      size: 48,
+      color: '#00FF00',
+      className: 'custom-class',
+      style: { margin: '10px' }
+    };
+
+    render(<MaterialSymbol {...props} />);
+    const icon = screen.getByText('star');
+
+    expect(icon).toHaveClass('material-symbols-sharp', 'custom-class');
+    
+    const style = window.getComputedStyle(icon);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 1`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'wght' 800`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'GRAD' -25`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'opsz' 48`);
+    expect(style.fontSize).toBe('48px');
+    expect(style.color).toBe('rgb(0, 255, 0)');
+    expect(style.margin).toBe('10px');
+  });
+
+  // Edge cases and validation
+  it('handles empty className', () => {
+    render(<MaterialSymbol symbol="home" className="" />);
+    const icon = screen.getByText('home');
+    
+    expect(icon).toHaveClass('material-symbols-outlined');
+    expect(icon.className.trim()).toBe('material-symbols-outlined');
+  });
+
+  it('handles undefined optional props', () => {
+    render(<MaterialSymbol symbol="home" type={undefined} fill={undefined} weight={undefined} />);
+    const icon = screen.getByText('home');
+    
+    expect(icon).toHaveClass('material-symbols-outlined');
+    const style = window.getComputedStyle(icon);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'FILL' 0`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'wght' 400`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'GRAD' 0`);
+    expect(style.getPropertyValue('font-variation-settings')).toContain(`'opsz' 24`);
+  });
+}); 

--- a/tests/utils/setup.tsx
+++ b/tests/utils/setup.tsx
@@ -3,15 +3,18 @@ import '@testing-library/jest-dom';
 
 // Mock CSS modules
 vi.mock('material-symbols', async () => {
-  const actual = await vi.importActual<typeof import('material-symbols')>('material-symbols');
+  const actual =
+    await vi.importActual<typeof import('material-symbols')>(
+      'material-symbols',
+    );
   return {
     ...actual,
     default: {},
     css: {
       'material-symbols-outlined': 'material-symbols-outlined',
       'material-symbols-rounded': 'material-symbols-rounded',
-      'material-symbols-sharp': 'material-symbols-sharp'
-    }
+      'material-symbols-sharp': 'material-symbols-sharp',
+    },
   };
 });
 
@@ -26,20 +29,24 @@ Object.defineProperty(window, 'getComputedStyle', {
           return match ? match[1].trim() : '';
         }
         return '';
-      }
+      },
     };
 
     // Get the inline styles
     const styleString = element.getAttribute('style') || '';
-    const styles = styleString.split(';').reduce((acc: { [key: string]: string }, style: string) => {
-      const [property, value] = style.split(':').map(s => s.trim());
-      if (property && value) {
-        // Convert CSS property names to camelCase
-        const camelProperty = property.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
-        acc[camelProperty] = value;
-      }
-      return acc;
-    }, {});
+    const styles = styleString
+      .split(';')
+      .reduce((acc: { [key: string]: string }, style: string) => {
+        const [property, value] = style.split(':').map((s) => s.trim());
+        if (property && value) {
+          // Convert CSS property names to camelCase
+          const camelProperty = property.replace(/-([a-z])/g, (g) =>
+            g[1].toUpperCase(),
+          );
+          acc[camelProperty] = value;
+        }
+        return acc;
+      }, {});
 
     // Handle inherited styles from parent elements
     let currentElement: HTMLElement | null = element;
@@ -74,9 +81,9 @@ Object.defineProperty(window, 'getComputedStyle', {
     // Return both the computed styles and the parsed inline styles
     return {
       ...computedStyles,
-      ...styles
+      ...styles,
     };
-  }
+  },
 });
 
 // Only keep any necessary global setup, remove all HeroUI mocks

--- a/tests/utils/setup.tsx
+++ b/tests/utils/setup.tsx
@@ -1,3 +1,82 @@
+import { vi } from 'vitest';
 import '@testing-library/jest-dom';
+
+// Mock CSS modules
+vi.mock('material-symbols', async () => {
+  const actual = await vi.importActual<typeof import('material-symbols')>('material-symbols');
+  return {
+    ...actual,
+    default: {},
+    css: {
+      'material-symbols-outlined': 'material-symbols-outlined',
+      'material-symbols-rounded': 'material-symbols-rounded',
+      'material-symbols-sharp': 'material-symbols-sharp'
+    }
+  };
+});
+
+// Configure jsdom
+Object.defineProperty(window, 'getComputedStyle', {
+  value: (element: HTMLElement) => {
+    const computedStyles: { [key: string]: any } = {
+      getPropertyValue: (prop: string) => {
+        if (prop === 'font-variation-settings') {
+          const style = element.getAttribute('style') || '';
+          const match = style.match(/font-variation-settings:\s*([^;]+)/);
+          return match ? match[1].trim() : '';
+        }
+        return '';
+      }
+    };
+
+    // Get the inline styles
+    const styleString = element.getAttribute('style') || '';
+    const styles = styleString.split(';').reduce((acc: { [key: string]: string }, style: string) => {
+      const [property, value] = style.split(':').map(s => s.trim());
+      if (property && value) {
+        // Convert CSS property names to camelCase
+        const camelProperty = property.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+        acc[camelProperty] = value;
+      }
+      return acc;
+    }, {});
+
+    // Handle inherited styles from parent elements
+    let currentElement: HTMLElement | null = element;
+    while (currentElement && !styles.color) {
+      const elementStyle = currentElement.getAttribute('style') || '';
+      const colorMatch = elementStyle.match(/color:\s*([^;]+)/);
+      if (colorMatch) {
+        styles.color = colorMatch[1].trim();
+        break;
+      }
+      currentElement = currentElement.parentElement;
+    }
+
+    // Handle color values
+    if (styles.color) {
+      // Convert hex to rgb
+      if (styles.color.startsWith('#')) {
+        const hex = styles.color.substring(1);
+        const r = parseInt(hex.substring(0, 2), 16);
+        const g = parseInt(hex.substring(2, 4), 16);
+        const b = parseInt(hex.substring(4, 6), 16);
+        styles.color = `rgb(${r}, ${g}, ${b})`;
+      }
+      // Convert color names to rgb
+      else if (styles.color === 'gold') styles.color = 'rgb(255, 215, 0)';
+      else if (styles.color === 'gray') styles.color = 'rgb(128, 128, 128)';
+      else if (styles.color === 'blue') styles.color = 'rgb(0, 0, 255)';
+      else if (styles.color === 'orange') styles.color = 'rgb(255, 165, 0)';
+      else if (styles.color === 'red') styles.color = 'rgb(255, 0, 0)';
+    }
+
+    // Return both the computed styles and the parsed inline styles
+    return {
+      ...computedStyles,
+      ...styles
+    };
+  }
+});
 
 // Only keep any necessary global setup, remove all HeroUI mocks

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,9 +13,9 @@ export default defineConfig({
     deps: {
       optimizer: {
         web: {
-          include: ['material-symbols']
-        }
-      }
+          include: ['material-symbols'],
+        },
+      },
     },
     mockReset: true,
     coverage: {
@@ -55,7 +55,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('.', import.meta.url)),
-      'material-symbols': fileURLToPath(new URL('./tests/__mocks__/material-symbols.ts', import.meta.url)),
+      'material-symbols': fileURLToPath(
+        new URL('./tests/__mocks__/material-symbols.ts', import.meta.url),
+      ),
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./tests/utils/setup.tsx'],
     css: true,
+    deps: {
+      optimizer: {
+        web: {
+          include: ['material-symbols']
+        }
+      }
+    },
+    mockReset: true,
     coverage: {
       reportsDirectory: './tests/coverage',
       enabled: true,
@@ -47,6 +55,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('.', import.meta.url)),
+      'material-symbols': fileURLToPath(new URL('./tests/__mocks__/material-symbols.ts', import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
This pull request introduces a new `MaterialSymbol` component for rendering Material Design icons with various customization options. It also includes updates to the testing setup and configuration to support this new component.

### New Component:

* [`app/components/materialSymbol.tsx`](diffhunk://#diff-51c40093ea62cf30e191621e1f5ee91886699dd53fa87b55841e2209a8844c7eR1-R51): Added `MaterialSymbol` component with customizable properties such as `symbol`, `type`, `fill`, `weight`, `grade`, `size`, `color`, `className`, and `style`.

### Dependency Addition:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R30): Added `material-symbols` package as a dependency.

### Mock and Testing Enhancements:

* [`tests/__mocks__/material-symbols.ts`](diffhunk://#diff-be8e65394b2afd04aea80bea37f4d8b42cd13a0745d1408578a61fba0694aa2bR1-R14): Created a mock for the `material-symbols` package to support testing.
* [`tests/integration/components/MaterialSymbol.test.tsx`](diffhunk://#diff-b4a2b5ba3f19eeaa33c98cceca71c86ef766daaba92cfb154481dabdf68670f5R1-R127): Added integration tests for the `MaterialSymbol` component to verify its behavior within different contexts and with dynamic changes.
* [`tests/unit/components/MaterialSymbol.test.tsx`](diffhunk://#diff-8f635c8fb09c18513e36e60feb18bf5db065f61df8d8e79dd7d30f766ad365a0R1-R133): Added unit tests for the `MaterialSymbol` component to check the rendering with default and custom properties, and edge cases.
* [`tests/utils/setup.tsx`](diffhunk://#diff-dabde97ef064495263f1bc4de005714458cb7052d03a20fed7eff5fee0bce25dR1-R81): Updated the test setup to include mocks for CSS modules and configure `jsdom` for style computations.

### Configuration Updates:

* [`vitest.config.ts`](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92R13-R20): Updated the Vitest configuration to include the `material-symbols` package in the dependency optimizer and set up aliasing for the mock. [[1]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92R13-R20) [[2]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92R58)